### PR TITLE
Fix error where argos cannot find CPFA_qt_user_functions

### DIFF
--- a/source/CPFA/CMakeLists.txt
+++ b/source/CPFA/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(loop_source_files CPFA_loop_functions.h CPFA_loop_functions.cpp)
 
 if (ARGOS_COMPILE_QTOPENGL)
-   set(source_files ${loop_source_files} CPFA_qt_user_functions.h CPFA_qt_user_functions.cpp)
+   set(loop_source_files ${loop_source_files} CPFA_qt_user_functions.h CPFA_qt_user_functions.cpp)
 endif()
 
 add_library(CPFA_loop_functions SHARED ${loop_source_files})


### PR DESCRIPTION
This has been tested and works with argos3-beta53 on linux (Ubuntu/Pop_OS 18.10) with argos built and installed from source.